### PR TITLE
Create databases via template_postgis

### DIFF
--- a/templates/sql/init-managed-db-user-and-role.sql.j2
+++ b/templates/sql/init-managed-db-user-and-role.sql.j2
@@ -13,7 +13,7 @@ $$;
 ALTER ROLE "{{ managed_db.username }}" PASSWORD '{{ managed_db.password }}';
 
 -- This will generate an error on subsequent execution
-CREATE DATABASE "{{ managed_db.name }}" WITH LC_CTYPE '{{ postgis_default_lc_type }}' LC_COLLATE '{{ postgis_default_lc_collate }}' OWNER "{{ managed_db.username }}";
+CREATE DATABASE "{{ managed_db.name }}" TEMPLATE "template_postgis" OWNER "{{ managed_db.username }}";
 
 -- This is useful for changing the database owner subsequently
 ALTER DATABASE "{{ managed_db.name }}" OWNER TO "{{ managed_db.username }}";


### PR DESCRIPTION
Fixes mobilizon (5.2.0) service `(Postgrex.Error) ERROR 42501 (insufficient_privilege) permission denied to create extension "postgis"` in mobilizon database